### PR TITLE
Fixed multiple wait indicator displayed at once

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,8 @@
 		<script src="js/main.js"></script>
 		<script>
 			/* Initialize the theme. */
-			Tendou.init();
+			var tendou = new Tendou();
+			tendou.init();
 		</script>
 	</body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 /* exported Tendou */
 /* jshint latedef: false */
-var Tendou = (function(lightdm) {
+function Tendou() {
   'use strict';
 
   /*
@@ -9,10 +9,13 @@ var Tendou = (function(lightdm) {
    *
    */
 
+  var self = this;
+  this._el_text_message    = null; // Messages to display to the user
+  this._el_wait_indicator  = null; // Displayed when the user must wait
+
   var el_form_login_form   = null, // Login form
       el_input_user        = null, // User input field
       el_list_user_list    = null, // List of users
-      el_text_message      = null, // Messages to display to the user
       el_heading_full_name = null, // Heading for the current user's full name
       el_figure_profile    = null, // Container for the current user's picture
       el_img_profile       = null, // Container for the current user's picture
@@ -77,7 +80,7 @@ var Tendou = (function(lightdm) {
           // Reset the password field and remove the wait indicator
           PrivateProp.el_input_pass.value = '';
           PrivateProp.el_input_pass.focus();
-          hide_wait_indicator();
+          self._hide_wait_indicator();
 
           // Restart authentication for the current user
           lightdm.start_authentication(lightdm.users[current_user_index].name);
@@ -91,7 +94,7 @@ var Tendou = (function(lightdm) {
        */
       window.show_error = function(text) {
         show_message(text);
-        el_text_message.classList.add('error');
+        self._el_text_message.classList.add('error');
       };
 
       /**
@@ -309,6 +312,15 @@ var Tendou = (function(lightdm) {
      */
     __test_framework__: Private,
     __test_framework_properties__: PrivateProp,
+
+    /**
+     * Expose prototype functions until the code is converted to use _ for privates
+    */
+
+    _el_text_message:     this._el_text_message,
+    _el_wait_indicator:   this._el_wait_indicator,
+    _show_wait_indicator: Tendou.prototype._show_wait_indicator,
+    _hide_wait_indicator: Tendou.prototype._hide_wait_indicator,
   };
 
 
@@ -324,7 +336,7 @@ var Tendou = (function(lightdm) {
     el_input_user        = document.getElementById('user');
     PrivateProp.el_input_pass = document.getElementById('password');
     el_list_user_list    = document.getElementById('user-list');
-    el_text_message      = document.getElementById('message');
+    self._el_text_message      = document.getElementById('message');
     el_heading_full_name = document.getElementById('login-name');
     el_figure_profile    = document.getElementById('profile-image');
     el_img_profile       = el_figure_profile.querySelector('img');
@@ -359,7 +371,7 @@ var Tendou = (function(lightdm) {
 
       // Clear all messages and display the waiting indicator
       clear_message();
-      show_wait_indicator();
+      self._show_wait_indicator();
 
       window.provide_secret();
     });
@@ -419,9 +431,9 @@ var Tendou = (function(lightdm) {
    * @param string text The message to display.
    */
   function show_message(text) {
-    el_text_message.innerHTML= text;
-    el_text_message.classList.remove('cleared');
-    el_text_message.classList.remove('error');
+    self._el_text_message.innerHTML= text;
+    self._el_text_message.classList.remove('cleared');
+    self._el_text_message.classList.remove('error');
   }
 
 
@@ -430,30 +442,7 @@ var Tendou = (function(lightdm) {
    */
   function clear_message() {
     show_message('');
-    el_text_message.classList.add('cleared');
-  }
-
-
-  /**
-   * Displays the wait indicator to the user.
-   */
-  function show_wait_indicator() {
-    el_text_message.insertAdjacentHTML(
-      'afterend',
-      '<div class="spinner"></div>'
-    );
-  }
-
-
-  /**
-   * Removes the wait indicator.
-   */
-  function hide_wait_indicator() {
-    var spinners = document.getElementsByClassName('spinner');
-
-    while (spinners[0]) {
-      spinners[0].parentNode.removeChild(spinners[0]);
-    }
+    self._el_text_message.classList.add('cleared');
   }
 
 
@@ -518,11 +507,39 @@ var Tendou = (function(lightdm) {
 
     // Clear all messages and the wait indicator
     clear_message();
-    hide_wait_indicator();
+    self._hide_wait_indicator();
   }
 
 
 
   // Expose the public interface
   return Public;
-} (lightdm));
+};
+
+
+/**
+ * Displays the wait indicator to the user.
+ * Only one wait indicator is displayed at a time.
+ */
+Tendou.prototype._show_wait_indicator = function() {
+  if (null === this._el_wait_indicator) {
+    this._el_wait_indicator = document.createElement('div');
+    this._el_wait_indicator.className = 'spinner';
+
+    this._el_text_message.insertAdjacentElement(
+      'afterend',
+      this._el_wait_indicator
+    );
+  }
+}
+
+
+/**
+ * Removes the wait indicator.
+ */
+Tendou.prototype._hide_wait_indicator = function() {
+  if (null !== this._el_wait_indicator) {
+    this._el_wait_indicator.remove();
+    this._el_wait_indicator = null;
+  }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -314,8 +314,10 @@ function Tendou() {
     __test_framework_properties__: PrivateProp,
 
     /**
-     * Expose prototype functions until the code is converted to use _ for privates
-    */
+     * Add function prototype here, because Tendou returns
+     * an object other than `this`. Should be refactored
+     * to not return a new object.
+     */
 
     _el_text_message:     this._el_text_message,
     _el_wait_indicator:   this._el_wait_indicator,
@@ -514,7 +516,7 @@ function Tendou() {
 
   // Expose the public interface
   return Public;
-};
+}
 
 
 /**
@@ -531,7 +533,7 @@ Tendou.prototype._show_wait_indicator = function() {
       this._el_wait_indicator
     );
   }
-}
+};
 
 
 /**
@@ -542,4 +544,4 @@ Tendou.prototype._hide_wait_indicator = function() {
     this._el_wait_indicator.remove();
     this._el_wait_indicator = null;
   }
-}
+};

--- a/tests/test_authentication.js
+++ b/tests/test_authentication.js
@@ -1,8 +1,11 @@
 /* jshint mocha: true */
 /* global Tendou, sinon, assert, beforeEach */
 describe('Tendou', function() {
-  var __Tendou__ = Tendou.__test_framework__;
-  var __Tendou_prop__ = Tendou.__test_framework_properties__;
+  var tendou, __Tendou__, __Tendou_prop__;
+
+  tendou = new Tendou();
+  __Tendou__ = tendou.__test_framework__;
+  __Tendou_prop__ = tendou.__test_framework_properties__;
 
   describe('LightDM authentication', function() {
     var fakes;

--- a/tests/test_keyboard_shortcuts.js
+++ b/tests/test_keyboard_shortcuts.js
@@ -2,12 +2,15 @@
 /* global Tendou, sinon, assert, after, beforeEach */
 describe('Tendou', function() {
   describe('__test_framework__', function() {
-    var __Tendou__ = Tendou.__test_framework__;
+    var tendou, __Tendou__;
+    
+    tendou = new Tendou();
+    __Tendou__ = tendou.__test_framework__;
 
     describe('init_keypress_handler()', function() {
       it('should register all keybindings', function() {
-        var registration_stub = sinon.stub(Tendou, 'register_keypress_handler');
-        Tendou.__test_framework__.init_keypress_handler();
+        var registration_stub = sinon.stub(tendou, 'register_keypress_handler');
+        __Tendou__.init_keypress_handler();
 
         assert.equal(
           window.onkeydown, __Tendou__.keypress_event_translator,
@@ -15,12 +18,12 @@ describe('Tendou', function() {
         );
 
         assert.isTrue(
-          registration_stub.calledWithExactly(40, Tendou.select_next_user),
+          registration_stub.calledWithExactly(40, tendou.select_next_user),
           'select_next_user keybinding was not registered'
         );
 
         assert.isTrue(
-          registration_stub.calledWithExactly(38, Tendou.select_previous_user),
+          registration_stub.calledWithExactly(38, tendou.select_previous_user),
           'select_previous_user keybinding was not registered'
         );
       });
@@ -75,9 +78,9 @@ describe('Tendou', function() {
       var handler_spy_2 = sinon.spy();
       var handler_spy_3 = sinon.spy();
 
-      Tendou.register_keypress_handler(0, handler_spy_1);
-      Tendou.register_keypress_handler(0, handler_spy_2);
-      Tendou.register_keypress_handler(1, handler_spy_3);
+      tendou.register_keypress_handler(0, handler_spy_1);
+      tendou.register_keypress_handler(0, handler_spy_2);
+      tendou.register_keypress_handler(1, handler_spy_3);
 
       beforeEach(function() {
         handler_spy_1.reset();

--- a/tests/test_user_index.js
+++ b/tests/test_user_index.js
@@ -2,9 +2,12 @@
 /* global Tendou, assert, after, before */
 describe('Tendou', function() {
   describe('__test_framework__', function() {
-    var __Tendou__ = Tendou.__test_framework__;
+    var tendou, __Tendou__;
 
     before(function() {
+      tendou = new Tendou();
+      __Tendou__ = tendou.__test_framework__;
+
       // Initialize the LightDM handlers before running these tests
       __Tendou__.init_lightdm_handlers();
     });

--- a/tests/test_wait_indicator.js
+++ b/tests/test_wait_indicator.js
@@ -1,0 +1,97 @@
+/* jshint mocha: true */
+/* global Tendou, sinon, assert */
+describe('wait indicator', function() {
+  var tendou, sandbox, createElement_stub, insertAdjacentElement_spy, remove_spy;
+
+  sandbox = sinon.sandbox.create();
+
+  beforeEach(function() {
+    tendou = new Tendou();
+
+    // Stub createElement to return an object with an empty className property
+    remove_spy = sandbox.spy();
+    createElement_stub = sandbox.stub(document, 'createElement', function() {
+      return {
+        className:  '',
+        remove:     remove_spy,
+      };
+    });
+
+    // Spy on the insertAdjacentElement call
+    insertAdjacentElement_spy = sandbox.spy()
+    tendou._el_text_message = {
+      insertAdjacentElement: insertAdjacentElement_spy,
+    };
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  it('should be added to the DOM', function() {
+    // Show the wait indicator
+    tendou._show_wait_indicator();
+
+    // Verify the indicator was added to the DOM
+    assert.equal(
+      tendou._el_wait_indicator,
+      insertAdjacentElement_spy.getCall(0).args[1],
+      'wait indicator element was not added to DOM'
+    );
+  });
+
+  it('should not show more than one indicator', function() {
+    // Attempt to display multiple wait indicators
+    tendou._show_wait_indicator();
+    tendou._show_wait_indicator();
+    tendou._show_wait_indicator();
+
+    // Verify the indicator was displayed once
+    assert.equal(
+      1, insertAdjacentElement_spy.callCount,
+      'wait indicator was not shown exactly once'
+    );
+  });
+
+  it('should not be hidden if it was never shown', function() {
+    // Attempt to hide the wait indicator when it was never shown
+    tendou._hide_wait_indicator();
+
+    // Verify that nothing happened
+    assert.equal(
+      0, remove_spy.callCount,
+      'attempted to remove wait indicator from DOM when it was never shown'
+    );
+  });
+
+  it('should be removed from DOM when hidden', function() {
+    // Show the wait indicator and hide it
+    tendou._show_wait_indicator();
+    tendou._hide_wait_indicator();
+
+    // Verify that the wait indicator was removed from the DOM
+    assert.equal(
+      1, remove_spy.callCount,
+      'hiding wait indicator did not remove it from DOM'
+    );
+  });
+
+  it('should be possible to show after hiding', function() {
+    // Show the wait indicator, hide it, then show it again
+    tendou._show_wait_indicator();
+    tendou._hide_wait_indicator();
+    tendou._show_wait_indicator();
+
+    // Verify that the wait indicator was added, removed, and added to the DOM
+    assert.isTrue(
+      insertAdjacentElement_spy.calledBefore(remove_spy),
+      'wait indicator not added to DOM before removing');
+    assert.isTrue(
+      remove_spy.calledBefore(insertAdjacentElement_spy),
+      'wait indicator did not remove from DOM before adding');
+    assert.equal(
+      2, insertAdjacentElement_spy.callCount,
+      'hiding wait indicator did not remove it from DOM'
+    );
+  });
+});

--- a/tests/test_wait_indicator.js
+++ b/tests/test_wait_indicator.js
@@ -1,7 +1,8 @@
 /* jshint mocha: true */
 /* global Tendou, sinon, assert */
 describe('wait indicator', function() {
-  var tendou, sandbox, createElement_stub, insertAdjacentElement_spy, remove_spy;
+  var tendou, sandbox,
+      createElement_stub, insertAdjacentElement_spy, remove_spy;
 
   sandbox = sinon.sandbox.create();
 
@@ -18,7 +19,7 @@ describe('wait indicator', function() {
     });
 
     // Spy on the insertAdjacentElement call
-    insertAdjacentElement_spy = sandbox.spy()
+    insertAdjacentElement_spy = sandbox.spy();
     tendou._el_text_message = {
       insertAdjacentElement: insertAdjacentElement_spy,
     };


### PR DESCRIPTION
This resolves #16 by not showing or hiding the wait indicator unless is in the opposite state. Tests have been added for this.

I've also moved the wait indicator functions to the function prototype for `Tendou`, and prefixed private members with `_`.